### PR TITLE
Fix: Hide mobile search form on desktop

### DIFF
--- a/src/Layout/NavMenu.razor.css
+++ b/src/Layout/NavMenu.razor.css
@@ -80,4 +80,8 @@
         height: calc(100vh - 3.5rem);
         overflow-y: auto;
     }
+
+    #mobileSearchForm {
+        display: none;
+    }
 }


### PR DESCRIPTION
The mobile search input form in NavMenu.razor is now hidden on screens wider than 641px. This is achieved by adding a CSS rule to `NavMenu.razor.css` that sets the `display` property of the `mobileSearchForm` element to `none` within the appropriate media query.